### PR TITLE
Add start in container (tech preview) command

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
 				"title": "Start..."
 			},
 			{
+				"command": "liberty.dev.start.container",
+				"category": "Open Liberty",
+				"title": "Start in container (tech preview)"
+			},
+			{
 				"command": "liberty.dev.run.tests",
 				"category": "Open Liberty",
 				"title": "Run tests"
@@ -105,37 +110,42 @@
 			"view/item/context": [
 				{
 					"command": "liberty.dev.start",
-					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject",
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject || viewItem == libertyMavenProjectContainer || viewItem == libertyGradleProjectContainer",
 					"group": "libertyCore@1"
 				},
 				{
 					"command": "liberty.dev.stop",
-					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject",
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject || viewItem == libertyMavenProjectContainer || viewItem == libertyGradleProjectContainer",
 					"group": "libertyCore@3"
 				},
 				{
 					"command": "liberty.dev.custom",
-					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject",
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject || viewItem == libertyMavenProjectContainer || viewItem == libertyGradleProjectContainer",
+					"group": "libertyCore@2"
+				},
+				{
+					"command": "liberty.dev.start.container",
+					"when": "viewItem == libertyMavenProjectContainer || viewItem == libertyGradleProjectContainer",
 					"group": "libertyCore@2"
 				},
 				{
 					"command": "liberty.dev.run.tests",
-					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject",
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject || viewItem == libertyMavenProjectContainer || viewItem == libertyGradleProjectContainer",
 					"group": "libertyCore@4"
 				},
 				{
 					"command": "liberty.dev.open.failsafe.report",
-					"when": "viewItem == libertyMavenProject",
+					"when": "viewItem == libertyMavenProject || viewItem == libertyMavenProjectContainer",
 					"group": "libertyCore@5"
 				},
 				{
 					"command": "liberty.dev.open.surefire.report",
-					"when": "viewItem == libertyMavenProject",
+					"when": "viewItem == libertyMavenProject || viewItem == libertyMavenProjectContainer",
 					"group": "libertyCore@6"
 				},
 				{
 					"command": "liberty.dev.open.gradle.test.report",
-					"when": "viewItem == libertyGradleProject",
+					"when": "viewItem == libertyGradleProject || viewItem == libertyGradleProjectContainer",
 					"group": "libertyCore@5"
 				}
 			],
@@ -150,6 +160,10 @@
 				},
 				{
 					"command": "liberty.dev.custom",
+					"when": "never"
+				},
+				{
+					"command": "liberty.dev.start.container",
 					"when": "never"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
 		"@types/xml2js": "^0.4.5",
 		"fs-extra": "^9.0.0",
 		"gradle-to-js": "^2.0.0",
+		"semver": "^7.3.2",
 		"xml2js": "^0.4.23"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,6 @@ import * as devCommands from "./utils/devCommands";
 import { LibertyProject, ProjectProvider } from "./utils/libertyProject";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-	console.log('"vscode-liberty-dev" extension is now active!');
 	const projectProvider = new ProjectProvider();
 
 	if (vscode.workspace.workspaceFolders !== undefined) {
@@ -29,6 +28,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand("liberty.dev.custom", (libProject?: LibertyProject) => devCommands.customDevMode(libProject)),
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand("liberty.dev.start.container", (libProject?: LibertyProject) => devCommands.startContainerDevMode(libProject)),
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand("liberty.dev.run.tests", (libProject?: LibertyProject) => devCommands.runTests(libProject)),

--- a/src/utils/GradleUtil.ts
+++ b/src/utils/GradleUtil.ts
@@ -168,11 +168,12 @@ function validParent(buildFile: any): GradleBuildFile {
  * 
  * @param version plugin version as string
  */
-function containerVersion(version: string): boolean {
-    if (version !== undefined) {
-        let versionStart = version.substring(0, 3);
-        if (parseFloat(versionStart) >= LIBERTY_GRADLE_PLUGIN_CONTAINER_VERSION) {
-            return true;
+function containerVersion(pluginVersion: string): boolean {
+    const semver = require('semver')
+    if (pluginVersion !== undefined) {
+        let version = semver.coerce(pluginVersion);
+        if (version != null) {
+            return semver.gte(version, LIBERTY_GRADLE_PLUGIN_CONTAINER_VERSION);
         }
     }
     return false;

--- a/src/utils/MavenUtil.ts
+++ b/src/utils/MavenUtil.ts
@@ -196,14 +196,14 @@ export function findChildMavenModules(xmlString: string): Map<string, string[]> 
  * @param plugin JS object for liberty-maven-plugin
  */
 function containerVersion(plugin: any): boolean {
+    const semver = require('semver')
     if (plugin.version === undefined) {
         return true;
     }
     if (plugin.version[0] !== undefined) {
-        // grab the first 2 digits, ie. if version is 3.3.1 return a float of `3.3`
-        let versionStart = plugin.version[0].substring(0,3);
-        if (parseFloat(versionStart) >= LIBERTY_MAVEN_PLUGIN_CONTAINER_VERSION) {
-            return true;
+        let version = semver.coerce(plugin.version[0]);
+        if (version != null) {
+            return semver.gte(version, LIBERTY_MAVEN_PLUGIN_CONTAINER_VERSION);
         }
     }
     return false;

--- a/src/utils/buildFile.ts
+++ b/src/utils/buildFile.ts
@@ -1,0 +1,61 @@
+interface IBuildFile {
+    buildFilePath: string;
+    projectType: string;
+    validBuildFile: boolean;
+    children?: string[]
+}
+
+/**
+ * Defines a general BuilFile object
+ */
+export class BuildFile implements IBuildFile{
+    buildFilePath: string;
+    projectType: string;
+    validBuildFile: boolean;
+
+    constructor (validBuildFile: boolean, projectType: string){
+        this.validBuildFile = validBuildFile;
+        this.projectType = projectType;
+        this.buildFilePath = "";
+    }
+
+    public getBuildFilePath() {
+        return this.buildFilePath;
+    }
+
+    public setBuildFilePath(buildFilePath: string) {
+        this.buildFilePath = buildFilePath;
+    }
+
+    public getProjectType() {
+        return this.projectType;
+    }
+
+    public setProjectType(projectType: string) {
+        this.projectType = projectType;
+    }
+
+    public isValidBuildFile() {
+        return this.validBuildFile;
+    }
+}
+
+/**
+ * Defines a Gradle Build File object
+ */
+export class GradleBuildFile extends BuildFile implements IBuildFile {
+    children: string[]; // list to track children associated with parent
+
+    constructor(validBuildFile: boolean, projectType: string) {
+        super(validBuildFile, projectType);
+        this.children = [];
+    }
+
+    public getChildren() {
+        return this.children;
+    }
+
+    public setChildren(children: string[]) {
+        this.children = children;
+    }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,5 +6,5 @@ export const TEST_REPORT_STRING = "Test Summary";
 export const LIBERTY_MAVEN_PROJECT_CONTAINER = "libertyMavenProjectContainer";
 export const LIBERTY_GRADLE_PROJECT_CONTAINER = "libertyGradleProjectContainer";
 
-export const LIBERTY_MAVEN_PLUGIN_CONTAINER_VERSION = 3.3;
-export const LIBERTY_GRADLE_PLUGIN_CONTAINER_VERSION = 3.1;
+export const LIBERTY_MAVEN_PLUGIN_CONTAINER_VERSION = `3.3.0`;
+export const LIBERTY_GRADLE_PLUGIN_CONTAINER_VERSION = `3.1.0`;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,10 @@
 export const LIBERTY_MAVEN_PROJECT = "libertyMavenProject";
 export const LIBERTY_GRADLE_PROJECT = "libertyGradleProject";
 export const TEST_REPORT_STRING = "Test Summary";
+
+// Liberty dev mode in containers
+export const LIBERTY_MAVEN_PROJECT_CONTAINER = "libertyMavenProjectContainer";
+export const LIBERTY_GRADLE_PROJECT_CONTAINER = "libertyGradleProjectContainer";
+
+export const LIBERTY_MAVEN_PLUGIN_CONTAINER_VERSION = 3.3;
+export const LIBERTY_GRADLE_PLUGIN_CONTAINER_VERSION = 3.1;

--- a/src/utils/libertyProject.ts
+++ b/src/utils/libertyProject.ts
@@ -4,7 +4,8 @@ import * as vscode from "vscode";
 import * as gradleUtil from "./GradleUtil";
 import * as mavenUtil from "./MavenUtil";
 import * as util from "./Util";
-import { LIBERTY_MAVEN_PROJECT, LIBERTY_GRADLE_PROJECT, LIBERTY_MAVEN_PROJECT_CONTAINER } from "./constants";
+import { LIBERTY_GRADLE_PROJECT } from "./constants";
+import { BuildFile, GradleBuildFile } from "./buildFile";
 
 export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> {
 	public readonly onDidChangeTreeData: vscode.Event<LibertyProject | undefined>;
@@ -49,43 +50,41 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 	}
 
 	// Given a list of pom.xml files, find ones that are valid to use with liberty dev-mode
-	private async findValidPOMs(pomPaths: string[]): Promise<[string, string][]> {
+	private async findValidPOMs(pomPaths: string[]): Promise<BuildFile[]> {
 		// [pom, liberty project type]
-		const validPoms: [string, string][] = [];
+		const validPoms: BuildFile[] = [];
 		let mavenChildMap: Map<string, string[]> = new Map();
 
 		// check for parentPoms
 		for (const parentPom of pomPaths) {
 			const xmlString: string = await fse.readFile(parentPom, "utf8");
-			const validParent = mavenUtil.validParentPom(xmlString);
-			if (validParent[0]) {
+			const validParent: BuildFile = mavenUtil.validParentPom(xmlString);
+			if (validParent.isValidBuildFile()) {
 				// mavenChildMap: [parentName, array of child names]
 				mavenChildMap = new Map([...Array.from(mavenChildMap.entries()), ...Array.from(mavenUtil.findChildMavenModules(xmlString).entries())]);
-
-				validPoms.push([parentPom, validParent[1]]);
+				validParent.setBuildFilePath(parentPom);
+				validPoms.push(validParent);
 			}
 		}
 
 		// check poms
 		for (const pomPath of pomPaths) {
-			if (!validPoms.includes([pomPath, LIBERTY_MAVEN_PROJECT_CONTAINER])
-				|| !validPoms.includes([pomPath, LIBERTY_MAVEN_PROJECT])) {
-
+			if (!validPoms.some(mavenPom => mavenPom['buildFilePath'] == pomPath)) {
 				const xmlString: string = await fse.readFile(pomPath, "utf8");
-				const validPom = mavenUtil.validPom(xmlString, mavenChildMap);
-				if (validPom[0]) {
-					validPoms.push([pomPath, validPom[1]]);
+				const validPom: BuildFile = mavenUtil.validPom(xmlString, mavenChildMap);
+				if (validPom.isValidBuildFile()) {
+					validPom.setBuildFilePath(pomPath);
+					validPoms.push(validPom);
 				}
 			}
 		}
-
 		return validPoms;
 	}
 
 	// Given a list of build.gradle files, find ones that are valid to use with liberty dev-mode
-	private async findValidGradleBuildFiles(gradlePaths: string[]): Promise<[string, string][]> {
+	private async findValidGradleBuildFiles(gradlePaths: string[]): Promise<BuildFile[]> {
 		// [gradle path, liberty project type]
-		const validGradleBuildFiles: [string, string][] = [];
+		const validGradleBuildFiles: BuildFile[] = [];
 		let gradleChildren: string[] = [];
 
 		// check for multi module build.gradles
@@ -96,10 +95,12 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 				const gradleSettings = gradleUtil.getGradleSettings(gradlePath);
 				if (gradleSettings !== "") {
 					await g2js.parseFile(gradleSettings).then(async (settingsFile: any) => {
-						const children = gradleUtil.findChildGradleProjects(buildFile, settingsFile);
-						if (children[1].length !== 0) {
-							gradleChildren = gradleChildren.concat(children[1]);
-							validGradleBuildFiles.push([gradlePath, children[0]]);
+						const gradleBuildFile: GradleBuildFile = gradleUtil.findChildGradleProjects(buildFile, settingsFile);
+						if (gradleBuildFile.getChildren().length !== 0) {
+							gradleChildren = gradleChildren.concat(gradleBuildFile.getChildren());
+							let gradleParent: GradleBuildFile = new GradleBuildFile(true, gradleBuildFile.getProjectType());
+							gradleParent.setBuildFilePath(gradlePath);
+							validGradleBuildFiles.push(gradleParent);
 						}
 					}).catch((err: any) => console.error("Unable to parse settings.gradle: " + gradleSettings + "; " + err));
 				}
@@ -116,11 +117,14 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 					// TODO: add ability to detect version of LMP once multi-module project scenarios are defined
 					// @see https://github.com/OpenLiberty/open-liberty-tools-vscode/issues/61
 					// @see https://github.com/OpenLiberty/open-liberty-tools-vscode/issues/26 
-					validGradleBuildFiles.push([gradlePath, LIBERTY_GRADLE_PROJECT]);
+					let gradleChild: GradleBuildFile = new GradleBuildFile(true, LIBERTY_GRADLE_PROJECT);
+					gradleChild.setBuildFilePath(gradlePath);
+					validGradleBuildFiles.push(gradleChild);
 				} else {
-					const gradleBuild = gradleUtil.validGradleBuild(buildFile);
-					if (gradleBuild[0]) {
-						validGradleBuildFiles.push([gradlePath, gradleBuild[1]]);
+					const gradleBuild: BuildFile = gradleUtil.validGradleBuild(buildFile);
+					if (gradleBuild.isValidBuildFile()) {
+						gradleBuild.setBuildFilePath(gradlePath);
+						validGradleBuildFiles.push(gradleBuild);
 					}
 				}
 			}).catch((err: any) => console.error("Unable to parse build.gradle: " + gradlePath + "; " + err));
@@ -134,54 +138,54 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 		const EXCLUDED_DIR_PATTERN = "**/{bin,classes,target}/**";
 		const pomPaths = (await vscode.workspace.findFiles("**/pom.xml", EXCLUDED_DIR_PATTERN)).map(uri => uri.fsPath);
 		const gradlePaths = (await vscode.workspace.findFiles("**/build.gradle", EXCLUDED_DIR_PATTERN)).map(uri => uri.fsPath);
-		const validPomPaths = await this.findValidPOMs(pomPaths);
-		const validGradlePaths = await this.findValidGradleBuildFiles(gradlePaths);
+		const validPoms: BuildFile[] = await this.findValidPOMs(pomPaths);
+		const validGradleBuilds: BuildFile[] = await this.findValidGradleBuildFiles(gradlePaths);
 
 		// map of buildFilePath -> LibertyProject
 		const newProjectsMap: Map<string, LibertyProject> = new Map();
 
-		for (const [pomPath, projectType] of validPomPaths) {
+		for (const pom of validPoms) {
 			// if a LibertyProject for this pom has already been created
 			// we want to re-use it since it stores state such as the terminal being used for dev-mode
-			if (this.projects.has(pomPath)) {
+			if (this.projects.has(pom.getBuildFilePath())) {
 				// check version of liberty-maven-plugin to see if it is valid for contatiners
-				const project = this.projects.get(pomPath);
+				const project = this.projects.get(pom.getBuildFilePath());
 				if (project !== undefined) {
-					if (project.contextValue != projectType) {
-						project.setContextValue(projectType);
+					if (project.contextValue != pom.getProjectType()) {
+						project.setContextValue(pom.getProjectType());
 					}
 				}
 
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				newProjectsMap.set(pomPath, this.projects.get(pomPath)!);
+				newProjectsMap.set(pom.getBuildFilePath(), this.projects.get(pom.getBuildFilePath())!);
 			}
 			// else we create a new LibertyProject for that POM
 			else {
-				const xmlString = await fse.readFile(pomPath, "utf8");
-				const project = await createProject(pomPath, projectType, xmlString);
-				newProjectsMap.set(pomPath, project);
+				const xmlString = await fse.readFile(pom.getBuildFilePath(), "utf8");
+				const project = await createProject(pom.getBuildFilePath(), pom.getProjectType(), xmlString);
+				newProjectsMap.set(pom.getBuildFilePath(), project);
 			}
 		}
 
-		for (const [gradlePath, projectType] of validGradlePaths) {
+		for (const gradleBuild of validGradleBuilds) {
 			// if a LibertyProject for this build.gradle has already been created
 			// we want to re-use it
-			if (this.projects.has(gradlePath)) {
+			if (this.projects.has(gradleBuild.getBuildFilePath())) {
 				// check version of liberty-gradle-plugin to see if it is valid for contatiners
-				const project = this.projects.get(gradlePath);
+				const project = this.projects.get(gradleBuild.getBuildFilePath());
 				if (project !== undefined) {
-					if (project.contextValue != projectType) {
-						project.setContextValue(projectType);
+					if (project.contextValue != gradleBuild.getProjectType()) {
+						project.setContextValue(gradleBuild.getProjectType());
 					}
 				}
 
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				newProjectsMap.set(gradlePath, this.projects.get(gradlePath)!);
+				newProjectsMap.set(gradleBuild.getBuildFilePath(), this.projects.get(gradleBuild.getBuildFilePath())!);
 			}
 			// else we create a new LibertyProject for that build file
 			else {
-				const project = await createProject(gradlePath, projectType);
-				newProjectsMap.set(gradlePath, project);
+				const project = await createProject(gradleBuild.getBuildFilePath(), gradleBuild.getProjectType());
+				newProjectsMap.set(gradleBuild.getBuildFilePath(), project);
 			}
 		}
 


### PR DESCRIPTION
Fixes #64 

Adds `Start in container (tech preview)` command for projects with the Liberty Maven Plugin version 3.3-M1 and higher or Liberty Gradle Plugin version 3.1-M1 and higher.

![image](https://user-images.githubusercontent.com/26146482/91349850-e4158800-e7b3-11ea-927f-1b1ba5b54273.png)
![image](https://user-images.githubusercontent.com/26146482/91349859-e5df4b80-e7b3-11ea-8765-4e3470d31966.png)

If there is no version specified for the LMP in the `pom.xml`, assume that the latest version of the LMP is downloaded from maven central and display the dev mode in container option.

Note: versions not specified explicitly in the `pom.xml` or `build.gradle` (ie. in specified in a separate file, in a parent build file) will not be picked up and will not display dev mode in container option.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>