### PR TITLE
Use build tool wrappers when enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ A VS Code extension for Open Liberty. The extension will detect your Liberty Mav
 | View integration test report | Views the integration test report file.                                                                                                                                                                                                                                                                                      |
 | View unit test report        | Views the unit test report file.                                                                                                                                                                                                                                                                                             |
 
+
 **Note:** Gradle projects only have a single `View test report` command.
+
+**Build Wrappers:**
+- Maven commands will honour the `maven.executable.path` setting. If this value is empty, Maven commands will attempt to use `mvn` or `mvnw` according to the `maven.executable.preferMavenWrapper` setting. Both of these settings are made available by the [Maven for Java extension](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-maven).
+- Gradle commands will honour the `java.import.gradle.wrapper.enabled` setting made available by the [Language support for Java extension](https://marketplace.visualstudio.com/items?itemName=redhat.java). If this setting is true, Gradle commands will attempt to use `gradlew` if a wrapper exists for the current project, otherwise will default to `gradle`.
 
 ## Configurable User Settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,9 +80,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.9.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz",
-			"integrity": "sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg=="
+			"version": "13.13.36",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.36.tgz",
+			"integrity": "sha512-ctzZJ+XsmHQwe3xp07gFUq4JxBaRSYzKHPgblR76//UanGST7vfFNF0+ty5eEbgTqsENopzoDK090xlha9dccQ=="
 		},
 		"@types/vscode": {
 			"version": "1.43.0",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
 	"devDependencies": {
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^7.0.2",
-		"@types/node": "^13.9.2",
+		"@types/node": "^13.13.36",
 		"@types/vscode": "^1.36.0",
 		"@typescript-eslint/eslint-plugin": "^2.24.0",
 		"@typescript-eslint/parser": "^2.24.0",

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -31,12 +31,12 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
             terminal.show();
             libProject.setTerminal(terminal);
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                let cmd = await mvnCmd(libProject.getPath());
-                cmd += ' io.openliberty.tools:liberty-maven-plugin:dev -f "' + libProject.getPath() + '"';
+                const mvnCmdStart = await mvnCmd(libProject.getPath());
+                const cmd = `${mvnCmdStart} io.openliberty.tools:liberty-maven-plugin:dev -f "${libProject.getPath()}"`;
                 terminal.sendText(cmd); // start dev mode on current project
             } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
-                let cmd = await gradleCmd(libProject.getPath());
-                cmd += ' libertyDev -b="' + libProject.getPath() + '"';
+                const gradleCmdStart = await gradleCmd(libProject.getPath());
+                const cmd = `${gradleCmdStart} libertyDev -b="${libProject.getPath()}"`;
                 terminal.sendText(cmd); // start dev mode on current project
             }
         }
@@ -102,12 +102,12 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
             if (customCommand !== undefined) {
                 _customParameters = customCommand;
                 if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                    let cmd = await mvnCmd(libProject.getPath());
-                    cmd += " io.openliberty.tools:liberty-maven-plugin:dev " + customCommand + ' -f "' + libProject.getPath() + '"';
+                    const mvnCmdStart = await mvnCmd(libProject.getPath());
+                    const cmd = `${mvnCmdStart} io.openliberty.tools:liberty-maven-plugin:dev ${customCommand} -f "${libProject.getPath()}"`;
                     terminal.sendText(cmd);
                 } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
-                    let cmd = await gradleCmd(libProject.getPath());
-                    cmd += " libertyDev " + customCommand + ' -b="' + libProject.getPath() + '"';
+                    const gradleCmdStart = await gradleCmd(libProject.getPath());
+                    const cmd = `${gradleCmdStart} libertyDev ${customCommand} -b="${libProject.getPath()}"`;
                     terminal.sendText(cmd);
                 }
             }
@@ -131,12 +131,12 @@ export async function startContainerDevMode(libProject?: LibertyProject | undefi
             terminal.show();
             libProject.setTerminal(terminal);
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                let cmd = await mvnCmd(libProject.getPath());
-                cmd += ' io.openliberty.tools:liberty-maven-plugin:devc -f "' + libProject.getPath() + '"';
+                const mvnCmdStart = await mvnCmd(libProject.getPath());
+                const cmd = `${mvnCmdStart} io.openliberty.tools:liberty-maven-plugin:devc -f "${libProject.getPath()}"`;
                 terminal.sendText(cmd);
             } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
-                let cmd = await gradleCmd(libProject.getPath());
-                cmd += " libertyDevc -b=" + libProject.getPath();
+                const gradleCmdStart = await gradleCmd(libProject.getPath());
+                const cmd = `${gradleCmdStart} libertyDevc -b="${libProject.getPath()}"`;
                 terminal.sendText(cmd);
             }
         }
@@ -210,33 +210,26 @@ export function deleteTerminal(terminal: vscode.Terminal): void {
 export async function mvnCmd(pomPath: string): Promise<string> {
 
     // attempt to use the Maven executable path, if empty try using mvn or mvnw according to the preferMavenWrapper setting
-    const mavenExecutablePath: any = vscode.workspace.getConfiguration("maven").get<boolean>("executable.path");
+    const mavenExecutablePath: string | undefined = vscode.workspace.getConfiguration("maven").get<string>("executable.path");
     if (mavenExecutablePath) {
         return mavenExecutablePath;
     }
-    const preferMavenWrapper: any = vscode.workspace.getConfiguration("maven").get<boolean>("executable.preferMavenWrapper");
-    console.log("preferMavenWrapper: " + preferMavenWrapper);
+    const preferMavenWrapper: boolean | undefined = vscode.workspace.getConfiguration("maven").get<boolean>("executable.preferMavenWrapper");
     if (preferMavenWrapper) {
         const localMvnwPath: string | undefined = await getLocalMavenWrapper(Path.dirname(pomPath));
         if (localMvnwPath) {
             return localMvnwPath;
-        } else {
-            return "mvn";
         }
     }
     return "mvn";
 }
 
 export async function gradleCmd(buildGradle: string): Promise<string> {
-    const preferGradleWrapper: any = vscode.workspace.getConfiguration("java").get<boolean>("import.gradle.wrapper.enabled");
-    console.log("preferGradleWrapper: " + preferGradleWrapper);
+    const preferGradleWrapper: boolean | undefined = vscode.workspace.getConfiguration("java").get<boolean>("import.gradle.wrapper.enabled");
     if (preferGradleWrapper) {
         const localGradlewPath: string | undefined = await getLocalGradleWrapper(Path.dirname(buildGradle));
         if (localGradlewPath) {
-            console.log("localGradlePath: " + localGradlewPath);
             return localGradlewPath;
-        } else {
-            return "gradle";
         }
     }
     return "gradle";

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -6,6 +6,7 @@ import { LibertyProject } from "./libertyProject";
 import { getReport } from "../util/helperUtil";
 import { LIBERTY_MAVEN_PROJECT, LIBERTY_GRADLE_PROJECT, LIBERTY_MAVEN_PROJECT_CONTAINER, LIBERTY_GRADLE_PROJECT_CONTAINER } from "../definitions/constants";
 import { getGradleTestReport } from "../util/gradleUtil";
+import { pathExists } from "fs-extra";
 
 export const terminals: { [libProjectId: number]: LibertyProject } = {};
 let _customParameters = "";
@@ -30,9 +31,13 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
             terminal.show();
             libProject.setTerminal(terminal);
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:dev -f "' + libProject.getPath() + '"'); // start dev mode on current project
+                let cmd = await mvnCmd(libProject.getPath());
+                cmd += ' io.openliberty.tools:liberty-maven-plugin:dev -f "' + libProject.getPath() + '"';
+                terminal.sendText(cmd); // start dev mode on current project
             } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
-                terminal.sendText("gradle libertyDev -b=" + libProject.getPath()); // start dev mode on current project
+                let cmd = await gradleCmd(libProject.getPath());
+                cmd += ' libertyDev -b="' + libProject.getPath() + '"';
+                terminal.sendText(cmd); // start dev mode on current project
             }
         }
     } else {
@@ -97,9 +102,13 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
             if (customCommand !== undefined) {
                 _customParameters = customCommand;
                 if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                    terminal.sendText("mvn io.openliberty.tools:liberty-maven-plugin:dev " + customCommand + ' -f "' + libProject.getPath() + '"');
+                    let cmd = await mvnCmd(libProject.getPath());
+                    cmd += " io.openliberty.tools:liberty-maven-plugin:dev " + customCommand + ' -f "' + libProject.getPath() + '"';
+                    terminal.sendText(cmd);
                 } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
-                    terminal.sendText("gradle libertyDev " + customCommand + ' -b="' + libProject.getPath() + '"');
+                    let cmd = await gradleCmd(libProject.getPath());
+                    cmd += " libertyDev " + customCommand + ' -b="' + libProject.getPath() + '"';
+                    terminal.sendText(cmd);
                 }
             }
         }
@@ -122,9 +131,13 @@ export async function startContainerDevMode(libProject?: LibertyProject | undefi
             terminal.show();
             libProject.setTerminal(terminal);
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:devc -f "' + libProject.getPath() + '"');
+                let cmd = await mvnCmd(libProject.getPath());
+                cmd += ' io.openliberty.tools:liberty-maven-plugin:devc -f "' + libProject.getPath() + '"';
+                terminal.sendText(cmd);
             } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
-                terminal.sendText("gradle libertyDevc -b=" + libProject.getPath());
+                let cmd = await gradleCmd(libProject.getPath());
+                cmd += " libertyDevc -b=" + libProject.getPath();
+                terminal.sendText(cmd);
             }
         }
     } else {
@@ -190,4 +203,91 @@ export function deleteTerminal(terminal: vscode.Terminal): void {
     } catch {
         console.error("Unable to delete terminal: " + terminal.name);
     }
+}
+
+
+// return Maven executable path, Maven wrapper, or mvn
+export async function mvnCmd(pomPath: string): Promise<string> {
+
+    // attempt to use the Maven executable path, if empty try using mvn or mvnw according to the preferMavenWrapper setting
+    const mavenExecutablePath: any = vscode.workspace.getConfiguration("maven").get<boolean>("executable.path");
+    if (mavenExecutablePath) {
+        return mavenExecutablePath;
+    }
+    const preferMavenWrapper: any = vscode.workspace.getConfiguration("maven").get<boolean>("executable.preferMavenWrapper");
+    console.log("preferMavenWrapper: " + preferMavenWrapper);
+    if (preferMavenWrapper) {
+        const localMvnwPath: string | undefined = await getLocalMavenWrapper(Path.dirname(pomPath));
+        if (localMvnwPath) {
+            return localMvnwPath;
+        } else {
+            return "mvn";
+        }
+    }
+    return "mvn";
+}
+
+export async function gradleCmd(buildGradle: string): Promise<string> {
+    const preferGradleWrapper: any = vscode.workspace.getConfiguration("java").get<boolean>("import.gradle.wrapper.enabled");
+    console.log("preferGradleWrapper: " + preferGradleWrapper);
+    if (preferGradleWrapper) {
+        const localGradlewPath: string | undefined = await getLocalGradleWrapper(Path.dirname(buildGradle));
+        if (localGradlewPath) {
+            console.log("localGradlePath: " + localGradlewPath);
+            return localGradlewPath;
+        } else {
+            return "gradle";
+        }
+    }
+    return "gradle";
+}
+
+/**
+ * Search for potential Maven wrapper, return undefined if does not exist
+ *
+ * Reused from vscode-maven
+ * https://github.com/microsoft/vscode-maven/blob/2ab8f392f418c8e0fe2903387f2b0013a1c50e78/src/utils/mavenUtils.ts
+ * @param projectFolder
+ */
+async function getLocalMavenWrapper(projectFolder: string): Promise<string | undefined> {
+    const mvnw: string = isWin() ? "mvnw.cmd" : "mvnw";
+
+    // walk up parent folders
+    let current: string = projectFolder;
+    while (Path.basename(current)) {
+        const potentialMvnwPath: string = Path.join(current, mvnw);
+        if (await pathExists(potentialMvnwPath)) {
+            return potentialMvnwPath;
+        }
+        current = Path.dirname(current);
+    }
+    return undefined;
+}
+
+/**
+ * Search for potential Gradle wrapper, return undefined if it does not exist
+ * Modified from vscode-maven, see getLocalMavenWrapper method above
+ * @param projectFolder
+ */
+async function getLocalGradleWrapper(projectFolder: string): Promise<string | undefined> {
+    const gradlew: string = isWin() ? "gradlew.bat" : "gradlew";
+
+    // walk up parent folders
+    let current: string = projectFolder;
+    while (Path.basename(current)) {
+        const potentialGradlewPath: string = Path.join(current, gradlew);
+        if (await pathExists(potentialGradlewPath)) {
+            return potentialGradlewPath;
+        }
+        current = Path.dirname(current);
+    }
+    return undefined;
+}
+
+/**
+ * Reused from vscode-maven
+ * https://github.com/microsoft/vscode-maven/blob/2ab8f392f418c8e0fe2903387f2b0013a1c50e78/src/utils/mavenUtils.ts
+ */
+function isWin(): boolean {
+    return process.platform.startsWith("win");
 }


### PR DESCRIPTION
Fixes #79 

If there is a value for the `maven.executable.path` setting, use this executable for Maven commands. Otherwise, if the `maven.executable.preferMavenWrapper` is true attempt to detect a `mvnw` file for the given `pom.xml` and use `mvnw`. Otherwise use `mvn`.

If the `java.import.gradle.wrapper.enabled` setting is true and we can detect a gradlew file in for the given `build.gradle`, Gradle commands will use `gradlew`, else will use `gradle`. 

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>