### PR TITLE
build liberty-ls project with gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,21 @@
 const gulp = require("gulp");
 const cp = require("child_process");
 
-const libertyLSName = "lemminx-liberty-1.0-SNAPSHOT-jar-with-dependencies.jar";
-const libertyLSDir = "../liberty-language-server/lemminx-liberty";
+const libertyLemminxName = "lemminx-liberty-1.0-SNAPSHOT-jar-with-dependencies.jar";
+const libertyLemminxDir = "../liberty-language-server/lemminx-liberty";
+const libertyLSName = "liberty.ls-1.0-SNAPSHOT-jar-with-dependencies.jar";
+const libertyLSDir = "../liberty-language-server/liberty-ls"
 
-gulp.task("buildServer", (done) => {
+gulp.task("buildLemminxLiberty", (done) => {
+  cp.execSync(mvnw() + " clean install -DskipTests", {
+    cwd: libertyLemminxDir,
+    stdio: "inherit",
+  });
+  gulp.src(libertyLemminxDir + "/target/" + libertyLemminxName).pipe(gulp.dest("./jars"));
+  done();
+});
+
+gulp.task("buildLibertyServer", (done) => {
   cp.execSync(mvnw() + " clean install -DskipTests", {
     cwd: libertyLSDir,
     stdio: "inherit",
@@ -12,6 +23,7 @@ gulp.task("buildServer", (done) => {
   gulp.src(libertyLSDir + "/target/" + libertyLSName).pipe(gulp.dest("./jars"));
   done();
 });
+
 
 function mvnw() {
   return isWin() ? "mvnw.cmd" : "./mvnw";

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "compile": "webpack --mode none",
     "watch": "webpack --mode development --watch --info-verbosity verbose",
     "test-compile": "tsc -p ./",
-    "build": "gulp buildServer"
+    "build": "gulp buildLemminxLiberty buildLibertyServer"
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",


### PR DESCRIPTION
As long as the directory structure is:

- open-liberty-tools-vscode
- liberty-language-server
   - lemminx-liberty
   - liberty-ls

Running `npm run build` on the `open-liberty-tools-vscode` project will build the lemminx-liberty and liberty-ls projects and copy the jars into the `jars` directory
 

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>