### PR TITLE
Fix launching liberty language server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,8 +15,8 @@
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
-			],
-			"preLaunchTask": "npm: watch"
+			]
+			// "preLaunchTask": "npm: watch",
 		},
 		{
 			"name": "Extension Tests",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,8 +15,9 @@
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
-			]
-			// "preLaunchTask": "npm: watch",
+			],
+			// "preLaunchTask": "npm: watch"
+			"command": "vscode.java.startDebugSession"
 		},
 		{
 			"name": "Extension Tests",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,9 +15,8 @@
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
-			],
+			]
 			// "preLaunchTask": "npm: watch"
-			"command": "vscode.java.startDebugSession"
 		},
 		{
 			"name": "Extension Tests",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "files.associations": {
+        "*.json": "jsonc"
+    }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We welcome contributions, and request you follow these guidelines.
 
 ## Raising issues
 
-Please raise any bug reports on the [issue tracker](https://github.com/OpenLiberty/liberty-dev-vscode-ext/issues). Be sure to search the list to see if your issue has already been raised.
+Please raise any bug reports on the [issue tracker](https://github.com/OpenLiberty/open-liberty-tools-vscode/issues). Be sure to search the list to see if your issue has already been raised.
 
 A good bug report is one that make it easy for us to understand what you were trying to do and what went wrong. Provide as much context as possible so we can try to recreate the issue.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Feature diagnostics for invalid features:
 ![Server.xml feature diagnostic](images/liberty-ls-prototype/feature-diagnostic.png)
 ---
 
-[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/Open-Liberty.liberty-dev-vscode-ext.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext)
+[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/Open-Liberty.open-liberty-tools-vscode.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.open-liberty-tools-vscode)
 [![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
 
 A VS Code extension for Open Liberty. The extension will detect your Liberty Maven or Liberty Gradle project if it detects the `io.openliberty.tools:liberty-maven-plugin` in the `pom.xml` or `io.openliberty.tools:liberty-gradle-plugin` in the `build.gradle`. Through the Liberty Dev Dashboard, you can start, stop, or interact with Liberty dev mode on all available [Liberty Maven](https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev) or [Liberty Gradle](https://github.com/OpenLiberty/ci.gradle/blob/master/docs/libertyDev.md) projects in your workspace.
@@ -100,17 +100,17 @@ Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pul
 
 To build the extension locally:
 
-1. `git clone https://github.com/OpenLiberty/liberty-dev-vscode-ext`
-2. `cd liberty-dev-vscode-ext`
+1. `git clone https://github.com/OpenLiberty/open-liberty-tools-vscode`
+2. `cd open-liberty-tools-vscode`
 3. Execute `npm install`
 4. Run the extension in Debug and Run mode by selecting `Run Extension` or `F5`
 
    Alternatively, build a `.vsix` file:
 
-   - `vsce package` to generate the `liberty-dev-vscode-ext-xxx.vsix` file
+   - `vsce package` to generate the `open-liberty-tools-vscode-xxx.vsix` file
    - Install the extension to VS Code by `View/Command Palette`
-   - Select `Extensions: Install from VSIX...` and choose the generated `liberty-dev-vscode-ext-xxx.vsix` file
+   - Select `Extensions: Install from VSIX...` and choose the generated `open-liberty-tools-vscode-xxx.vsix` file
 
 ## Issues
 
-Please report bugs, issues and feature requests by creating a [GitHub issue](https://github.com/OpenLiberty/liberty-dev-vscode-ext/issues).
+Please report bugs, issues and feature requests by creating a [GitHub issue](https://github.com/OpenLiberty/open-liberty-tools-vscode/issues).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4570,9 +4570,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -10831,9 +10831,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,7 +120,8 @@ function startupLanguageServer(context: ExtensionContext) {
             command: "java",
             // TODO: using the debug arguments seems to still run the language server and open the debug port,
             // but, the extension doesn't seem to work properly nor does it run the .onReady.then() commands
-            args: [debugArgs, "-jar", languageServerPath],
+            // args: [debugArgs, "-jar", languageServerPath],
+            args: ["-jar", languageServerPath],
             options: {stdio:"pipe"}
         }
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,16 +22,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         console.log("Language client ready, registering commands");
         
         item.text = "Liberty LS $(thumbsup)";
-		item.tooltip = "Language Server for Liberty started";
-		toggleItem(window.activeTextEditor, item);
+        item.tooltip = "Language Server for Liberty started";
+        toggleItem(window.activeTextEditor, item);
 
         registerCommands(context);
     }, error => {
         console.log("Language client was not ready. Did not initialize");
         console.log(error);
         
-		item.text = "Liberty LS $(thumbsdown)";
-		item.tooltip = "Language Server for Liberty failed to start";
+        item.text = "Liberty LS $(thumbsdown)";
+        item.tooltip = "Language Server for Liberty failed to start";
     });
 }
 
@@ -147,9 +147,9 @@ function startupLanguageServer(context: ExtensionContext) {
 }
 
 function toggleItem(editor: TextEditor | undefined, item: vscode.StatusBarItem) {
-	if(editor && editor.document && SUPPORTED_LANGUAGE_IDS.includes(editor.document.languageId)){
-		item.show();
-	} else{
-		item.hide();
-	}
+    if(editor && editor.document && SUPPORTED_LANGUAGE_IDS.includes(editor.document.languageId)){
+        item.show();
+    } else{
+        item.hide();
+    }
 }

--- a/src/liberty/libertyProject.ts
+++ b/src/liberty/libertyProject.ts
@@ -29,7 +29,7 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 		// update the map of projects
 		await this.updateProjects();
 		// trigger a re-render of the tree view
-		this._onDidChangeTreeData.fire();
+		this._onDidChangeTreeData.fire(undefined);
 	}
 
 	public getTreeItem(element: LibertyProject): vscode.TreeItem {


### PR DESCRIPTION
This fixes the call `this._onDidChangeTreeData.fire()` which seems to now require an argument for the project to build properly.

Also:
- Refactored some code, and made some changes based on ES6 linter best practices.
- Fixed some old references and links.
- Added status bar icon to show the Liberty LS status: starting, started, or errored.
- Prepare Liberty LS for java debugging (something still doesn't work)
- Quality of life change to set VSCode language for JSON files to JSON with comments
- Commented out the npm:watch command in launch.json - it always errored and just added an extra click to run